### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/database": "^5.2|~5.5.x-dev",
-        "illuminate/support": "^5.2|~5.5.x-dev"
+        "illuminate/database": "^5.2|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/support": "^5.2|~5.5.x-dev|~5.5.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2",
-        "orchestra/testbench": "^3.2|~3.5.x-dev"
+        "orchestra/testbench": "^3.2|~3.5.x-dev|~3.5.x-dev"
     },
     "autoload": {
         "psr-4": {
@@ -38,3 +38,4 @@
         "test": "vendor/bin/phpunit"
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         }
     ],
     "require": {
-        "php" : "^7.0",
-        "illuminate/database": "^5.2",
-        "illuminate/support": "^5.2"
+        "php": "^7.0",
+        "illuminate/database": "^5.2|~5.5.x-dev",
+        "illuminate/support": "^5.2|~5.5.x-dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*",
-        "orchestra/testbench": "^3.2"
+        "phpunit/phpunit": "^6.2",
+        "orchestra/testbench": "^3.2|~3.5.x-dev"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-relatable/phpunit.xml.dist

.....E.....                                                       11 / 11 (100%)

Time: 3.85 seconds, Memory: 12.00MB

There was 1 error:

1) Spatie\Relatable\Test\HasRelatedContentTest::it_can_retrieve_a_collection_of_its_related_content
TypeError: Argument 2 passed to Spatie\Relatable\Test\TestCase::Spatie\Relatable\Test\{closure}() must be an instance of Illuminate\Database\Eloquent\Model, integer given

/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-relatable/tests/TestCase.php:82
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-relatable/vendor/laravel/framework/src/Illuminate/Support/Arr.php:175
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-relatable/vendor/laravel/framework/src/Illuminate/Support/Collection.php:578
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-relatable/vendor/laravel/framework/src/Illuminate/Support/Collection.php:221
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-relatable/tests/TestCase.php:84
/Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-relatable/tests/HasRelatedContentTest.php:78

ERRORS!
Tests: 11, Assertions: 19, Errors: 1.

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

So there are some errors, but it could work!